### PR TITLE
Only show frame picker on single frame

### DIFF
--- a/src/Editor/Panels/Inspector/Inspector.jsx
+++ b/src/Editor/Panels/Inspector/Inspector.jsx
@@ -596,10 +596,12 @@ class Inspector extends Component {
           tooltip="Synced" 
           checked={this.getSelectionAttribute('isSynced')}
           onChange={(val) => this.setSelectionAttribute('isSynced', !this.getSelectionAttribute('isSynced'))}/>}
+        {
+          this.getSelectionAttribute('singleFrameNumber') &&
           <InspectorFramePicker
             project={this.props.project}
             getActive={() => this.getSelectionAttribute('singleFrameNumber')}
-            onChange={(val) => this.setSelectionAttribute('singleFrameNumber', val)} />
+            onChange={(val) => this.setSelectionAttribute('singleFrameNumber', val)} />}
       </div>
     )
   }


### PR DESCRIPTION
The frame picker won't work for "Loop" or "Play Once" clips, so why show it? Untested.
Edit: Okay so I just pushed it and it works.