### PR TITLE
Fix settings modal overflow

### DIFF
--- a/src/Editor/Modals/SettingsModal/EditorSettings/_editorsettings.scss
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/_editorsettings.scss
@@ -22,6 +22,10 @@
 .editor-settings-modal-body {
   width: 100%;
   height: 100%;
+  overflow: hidden;
+}
+.editor-settings-modal-body:hover {
+  overflow-y: scroll;
 }
 
 .editor-settings-group {


### PR DESCRIPTION
The editor tab in settings overflows with the onion skin color and the clip opacity slider turned on. It's not that much of a change.