### PR TITLE
Fix scrollbar showing when not needed

### DIFF
--- a/src/Editor/Modals/SettingsModal/EditorSettings/_editorsettings.scss
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/_editorsettings.scss
@@ -25,7 +25,7 @@
   overflow: hidden;
 }
 .editor-settings-modal-body:hover {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .editor-settings-group {


### PR DESCRIPTION
Now, the scrollbar shows even if it doesn't overflow. This should fix it once and for all.