### PR TITLE
Add recursive outside view and view borders

### DIFF
--- a/engine/dist/emptyproject.html
+++ b/engine/dist/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.2.13.10.9.18";
+var WICK_ENGINE_BUILD_VERSION = "2025.2.13.13.48.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -46886,6 +46886,10 @@ Wick.ToolSettings = class {
       min: 0,
       max: 1,
       step: 0.01
+    }, {
+      type: "boolean",
+      name: 'outsideClipShowBorder',
+      default: false
     }];
   }
   /**
@@ -62234,6 +62238,8 @@ class SelectionWidget {
 
 
   scaleSelection(scale, pivot) {
+    if (!pivot) pivot = this.pivot;
+
     this._itemsInSelection.forEach(item => {
       item.rotate(-this.boxRotation, this.pivot);
       item.scale(scale, pivot);
@@ -63279,8 +63285,14 @@ Wick.View.Project = class extends Wick.View {
       // We're in the root timeline, use the color given to us from the user (or use a default)
       this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
     } else {
-      // We're inside a clip, so use the project background color as the container background color
-      this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      // We're inside a clip
+      if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+        // Use the same color as the root
+        this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
+      } else {
+        // Use the project background color as the container background color
+        this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      }
     }
   }
 
@@ -63351,12 +63363,7 @@ Wick.View.Project = class extends Wick.View {
 
     var pan = this._pan;
     this.paper.view.center = new paper.Point(-pan.x, -pan.y);
-    this.paper.view.rotation = this.model.rotation; // Generate background layer
-
-    this._svgBackgroundLayer.removeChildren();
-
-    this._svgBackgroundLayer.locked = true;
-    this.paper.project.addLayer(this._svgBackgroundLayer);
+    this.paper.view.rotation = this.model.rotation; // Add transformed objects layer before background
 
     this._svgOuterLayer.removeChildren();
 
@@ -63364,7 +63371,12 @@ Wick.View.Project = class extends Wick.View {
 
     this._svgOuterLayer.locked = true;
     this._svgOuterLayer.opacity = 1;
-    this.paper.project.addLayer(this._svgOuterLayer);
+    this.paper.project.addLayer(this._svgOuterLayer); // Generate background layer
+
+    this._svgBackgroundLayer.removeChildren();
+
+    this._svgBackgroundLayer.locked = true;
+    this.paper.project.addLayer(this._svgBackgroundLayer);
 
     if (this.model.focus.isRoot) {
       // We're in the root timeline, render the canvas normally
@@ -63372,28 +63384,44 @@ Wick.View.Project = class extends Wick.View {
 
       this._svgBackgroundLayer.addChild(stage);
     } else {
-      // We're inside a clip, don't render the canvas BG, instead render a crosshair at (0,0)
+      // We're inside a clip, don't render the canvas BG directly, instead render a crosshair at (0,0)
       var originCrosshair = this._generateSVGOriginCrosshair();
 
       this._svgBackgroundLayer.addChild(originCrosshair);
 
       if (this.model.toolSettings.getSetting('outsideClipStyle') !== 'none') {
-        var thisParentLayer = this.model.focus.parentLayer;
-        var thisParentTimeline = thisParentLayer.parentTimeline;
-        thisParentTimeline.view.render();
+        if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+          this._svgOuterLayer.addChild(this._generateSVGCanvasStage());
+        }
+
+        var rootTimeline = this.model.root.timeline;
+        var objectsGroup = new paper.Group();
+
+        this._svgOuterLayer.addChild(objectsGroup);
+
+        rootTimeline.view.render();
         this.model.focus.view.group.remove();
-        thisParentTimeline.view.frameLayers.forEach(layer => {
-          this._svgOuterLayer.addChild(layer);
+        rootTimeline.view.frameLayers.forEach(layer => {
+          objectsGroup.addChild(layer);
+        }); // Apply visual effects
+
+        var transformations = [];
+        var clipIteration = this.model.focus;
+
+        while (!clipIteration.isRoot) {
+          transformations.push(clipIteration.transformation);
+          clipIteration = clipIteration.parentClip;
+        }
+
+        transformations.reverse();
+        transformations.forEach(transform => {
+          this._svgOuterLayer.translate(-transform.x, -transform.y);
+
+          this._svgOuterLayer.rotate(-transform.rotation, new paper.Point());
+
+          this._svgOuterLayer.scale(1 / transform.scaleX, 1 / transform.scaleY, new paper.Point());
         });
-        var thisClipTransformation = this.model.focus.transformation;
-
-        this._svgOuterLayer.translate(-thisClipTransformation.x, -thisClipTransformation.y);
-
-        this._svgOuterLayer.rotate(-thisClipTransformation.rotation, new paper.Point());
-
-        this._svgOuterLayer.scale(1 / thisClipTransformation.scaleX, 1 / thisClipTransformation.scaleY, new paper.Point());
-
-        this._svgOuterLayer.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
+        objectsGroup.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
       }
     } // Generate frame layers
 

--- a/engine/dist/wickengine.js
+++ b/engine/dist/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.2.13.10.9.18";
+var WICK_ENGINE_BUILD_VERSION = "2025.2.13.13.48.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -46871,6 +46871,10 @@ Wick.ToolSettings = class {
       min: 0,
       max: 1,
       step: 0.01
+    }, {
+      type: "boolean",
+      name: 'outsideClipShowBorder',
+      default: false
     }];
   }
   /**
@@ -62219,6 +62223,8 @@ class SelectionWidget {
 
 
   scaleSelection(scale, pivot) {
+    if (!pivot) pivot = this.pivot;
+
     this._itemsInSelection.forEach(item => {
       item.rotate(-this.boxRotation, this.pivot);
       item.scale(scale, pivot);
@@ -63264,8 +63270,14 @@ Wick.View.Project = class extends Wick.View {
       // We're in the root timeline, use the color given to us from the user (or use a default)
       this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
     } else {
-      // We're inside a clip, so use the project background color as the container background color
-      this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      // We're inside a clip
+      if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+        // Use the same color as the root
+        this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
+      } else {
+        // Use the project background color as the container background color
+        this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      }
     }
   }
 
@@ -63336,12 +63348,7 @@ Wick.View.Project = class extends Wick.View {
 
     var pan = this._pan;
     this.paper.view.center = new paper.Point(-pan.x, -pan.y);
-    this.paper.view.rotation = this.model.rotation; // Generate background layer
-
-    this._svgBackgroundLayer.removeChildren();
-
-    this._svgBackgroundLayer.locked = true;
-    this.paper.project.addLayer(this._svgBackgroundLayer);
+    this.paper.view.rotation = this.model.rotation; // Add transformed objects layer before background
 
     this._svgOuterLayer.removeChildren();
 
@@ -63349,7 +63356,12 @@ Wick.View.Project = class extends Wick.View {
 
     this._svgOuterLayer.locked = true;
     this._svgOuterLayer.opacity = 1;
-    this.paper.project.addLayer(this._svgOuterLayer);
+    this.paper.project.addLayer(this._svgOuterLayer); // Generate background layer
+
+    this._svgBackgroundLayer.removeChildren();
+
+    this._svgBackgroundLayer.locked = true;
+    this.paper.project.addLayer(this._svgBackgroundLayer);
 
     if (this.model.focus.isRoot) {
       // We're in the root timeline, render the canvas normally
@@ -63357,28 +63369,44 @@ Wick.View.Project = class extends Wick.View {
 
       this._svgBackgroundLayer.addChild(stage);
     } else {
-      // We're inside a clip, don't render the canvas BG, instead render a crosshair at (0,0)
+      // We're inside a clip, don't render the canvas BG directly, instead render a crosshair at (0,0)
       var originCrosshair = this._generateSVGOriginCrosshair();
 
       this._svgBackgroundLayer.addChild(originCrosshair);
 
       if (this.model.toolSettings.getSetting('outsideClipStyle') !== 'none') {
-        var thisParentLayer = this.model.focus.parentLayer;
-        var thisParentTimeline = thisParentLayer.parentTimeline;
-        thisParentTimeline.view.render();
+        if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+          this._svgOuterLayer.addChild(this._generateSVGCanvasStage());
+        }
+
+        var rootTimeline = this.model.root.timeline;
+        var objectsGroup = new paper.Group();
+
+        this._svgOuterLayer.addChild(objectsGroup);
+
+        rootTimeline.view.render();
         this.model.focus.view.group.remove();
-        thisParentTimeline.view.frameLayers.forEach(layer => {
-          this._svgOuterLayer.addChild(layer);
+        rootTimeline.view.frameLayers.forEach(layer => {
+          objectsGroup.addChild(layer);
+        }); // Apply visual effects
+
+        var transformations = [];
+        var clipIteration = this.model.focus;
+
+        while (!clipIteration.isRoot) {
+          transformations.push(clipIteration.transformation);
+          clipIteration = clipIteration.parentClip;
+        }
+
+        transformations.reverse();
+        transformations.forEach(transform => {
+          this._svgOuterLayer.translate(-transform.x, -transform.y);
+
+          this._svgOuterLayer.rotate(-transform.rotation, new paper.Point());
+
+          this._svgOuterLayer.scale(1 / transform.scaleX, 1 / transform.scaleY, new paper.Point());
         });
-        var thisClipTransformation = this.model.focus.transformation;
-
-        this._svgOuterLayer.translate(-thisClipTransformation.x, -thisClipTransformation.y);
-
-        this._svgOuterLayer.rotate(-thisClipTransformation.rotation, new paper.Point());
-
-        this._svgOuterLayer.scale(1 / thisClipTransformation.scaleX, 1 / thisClipTransformation.scaleY, new paper.Point());
-
-        this._svgOuterLayer.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
+        objectsGroup.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
       }
     } // Generate frame layers
 

--- a/engine/src/ToolSettings.js
+++ b/engine/src/ToolSettings.js
@@ -125,6 +125,10 @@ Wick.ToolSettings = class {
             min: 0,
             max: 1,
             step: 0.01,
+        }, {
+            type: "boolean",
+            name: 'outsideClipShowBorder',
+            default: false
         }];
     }
 

--- a/public/corelibs/wick-engine/emptyproject.html
+++ b/public/corelibs/wick-engine/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.2.13.10.9.18";
+var WICK_ENGINE_BUILD_VERSION = "2025.2.13.13.48.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -46886,6 +46886,10 @@ Wick.ToolSettings = class {
       min: 0,
       max: 1,
       step: 0.01
+    }, {
+      type: "boolean",
+      name: 'outsideClipShowBorder',
+      default: false
     }];
   }
   /**
@@ -62234,6 +62238,8 @@ class SelectionWidget {
 
 
   scaleSelection(scale, pivot) {
+    if (!pivot) pivot = this.pivot;
+
     this._itemsInSelection.forEach(item => {
       item.rotate(-this.boxRotation, this.pivot);
       item.scale(scale, pivot);
@@ -63279,8 +63285,14 @@ Wick.View.Project = class extends Wick.View {
       // We're in the root timeline, use the color given to us from the user (or use a default)
       this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
     } else {
-      // We're inside a clip, so use the project background color as the container background color
-      this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      // We're inside a clip
+      if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+        // Use the same color as the root
+        this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
+      } else {
+        // Use the project background color as the container background color
+        this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      }
     }
   }
 
@@ -63351,12 +63363,7 @@ Wick.View.Project = class extends Wick.View {
 
     var pan = this._pan;
     this.paper.view.center = new paper.Point(-pan.x, -pan.y);
-    this.paper.view.rotation = this.model.rotation; // Generate background layer
-
-    this._svgBackgroundLayer.removeChildren();
-
-    this._svgBackgroundLayer.locked = true;
-    this.paper.project.addLayer(this._svgBackgroundLayer);
+    this.paper.view.rotation = this.model.rotation; // Add transformed objects layer before background
 
     this._svgOuterLayer.removeChildren();
 
@@ -63364,7 +63371,12 @@ Wick.View.Project = class extends Wick.View {
 
     this._svgOuterLayer.locked = true;
     this._svgOuterLayer.opacity = 1;
-    this.paper.project.addLayer(this._svgOuterLayer);
+    this.paper.project.addLayer(this._svgOuterLayer); // Generate background layer
+
+    this._svgBackgroundLayer.removeChildren();
+
+    this._svgBackgroundLayer.locked = true;
+    this.paper.project.addLayer(this._svgBackgroundLayer);
 
     if (this.model.focus.isRoot) {
       // We're in the root timeline, render the canvas normally
@@ -63372,28 +63384,44 @@ Wick.View.Project = class extends Wick.View {
 
       this._svgBackgroundLayer.addChild(stage);
     } else {
-      // We're inside a clip, don't render the canvas BG, instead render a crosshair at (0,0)
+      // We're inside a clip, don't render the canvas BG directly, instead render a crosshair at (0,0)
       var originCrosshair = this._generateSVGOriginCrosshair();
 
       this._svgBackgroundLayer.addChild(originCrosshair);
 
       if (this.model.toolSettings.getSetting('outsideClipStyle') !== 'none') {
-        var thisParentLayer = this.model.focus.parentLayer;
-        var thisParentTimeline = thisParentLayer.parentTimeline;
-        thisParentTimeline.view.render();
+        if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+          this._svgOuterLayer.addChild(this._generateSVGCanvasStage());
+        }
+
+        var rootTimeline = this.model.root.timeline;
+        var objectsGroup = new paper.Group();
+
+        this._svgOuterLayer.addChild(objectsGroup);
+
+        rootTimeline.view.render();
         this.model.focus.view.group.remove();
-        thisParentTimeline.view.frameLayers.forEach(layer => {
-          this._svgOuterLayer.addChild(layer);
+        rootTimeline.view.frameLayers.forEach(layer => {
+          objectsGroup.addChild(layer);
+        }); // Apply visual effects
+
+        var transformations = [];
+        var clipIteration = this.model.focus;
+
+        while (!clipIteration.isRoot) {
+          transformations.push(clipIteration.transformation);
+          clipIteration = clipIteration.parentClip;
+        }
+
+        transformations.reverse();
+        transformations.forEach(transform => {
+          this._svgOuterLayer.translate(-transform.x, -transform.y);
+
+          this._svgOuterLayer.rotate(-transform.rotation, new paper.Point());
+
+          this._svgOuterLayer.scale(1 / transform.scaleX, 1 / transform.scaleY, new paper.Point());
         });
-        var thisClipTransformation = this.model.focus.transformation;
-
-        this._svgOuterLayer.translate(-thisClipTransformation.x, -thisClipTransformation.y);
-
-        this._svgOuterLayer.rotate(-thisClipTransformation.rotation, new paper.Point());
-
-        this._svgOuterLayer.scale(1 / thisClipTransformation.scaleX, 1 / thisClipTransformation.scaleY, new paper.Point());
-
-        this._svgOuterLayer.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
+        objectsGroup.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
       }
     } // Generate frame layers
 

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2025.2.13.10.9.18";
+var WICK_ENGINE_BUILD_VERSION = "2025.2.13.13.48.58";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -46871,6 +46871,10 @@ Wick.ToolSettings = class {
       min: 0,
       max: 1,
       step: 0.01
+    }, {
+      type: "boolean",
+      name: 'outsideClipShowBorder',
+      default: false
     }];
   }
   /**
@@ -62219,6 +62223,8 @@ class SelectionWidget {
 
 
   scaleSelection(scale, pivot) {
+    if (!pivot) pivot = this.pivot;
+
     this._itemsInSelection.forEach(item => {
       item.rotate(-this.boxRotation, this.pivot);
       item.scale(scale, pivot);
@@ -63264,8 +63270,14 @@ Wick.View.Project = class extends Wick.View {
       // We're in the root timeline, use the color given to us from the user (or use a default)
       this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
     } else {
-      // We're inside a clip, so use the project background color as the container background color
-      this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      // We're inside a clip
+      if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+        // Use the same color as the root
+        this.canvas.style.backgroundColor = this.canvasBGColor || Wick.View.Project.DEFAULT_CANVAS_BG_COLOR;
+      } else {
+        // Use the project background color as the container background color
+        this.canvas.style.backgroundColor = this.model.backgroundColor.hex;
+      }
     }
   }
 
@@ -63336,12 +63348,7 @@ Wick.View.Project = class extends Wick.View {
 
     var pan = this._pan;
     this.paper.view.center = new paper.Point(-pan.x, -pan.y);
-    this.paper.view.rotation = this.model.rotation; // Generate background layer
-
-    this._svgBackgroundLayer.removeChildren();
-
-    this._svgBackgroundLayer.locked = true;
-    this.paper.project.addLayer(this._svgBackgroundLayer);
+    this.paper.view.rotation = this.model.rotation; // Add transformed objects layer before background
 
     this._svgOuterLayer.removeChildren();
 
@@ -63349,7 +63356,12 @@ Wick.View.Project = class extends Wick.View {
 
     this._svgOuterLayer.locked = true;
     this._svgOuterLayer.opacity = 1;
-    this.paper.project.addLayer(this._svgOuterLayer);
+    this.paper.project.addLayer(this._svgOuterLayer); // Generate background layer
+
+    this._svgBackgroundLayer.removeChildren();
+
+    this._svgBackgroundLayer.locked = true;
+    this.paper.project.addLayer(this._svgBackgroundLayer);
 
     if (this.model.focus.isRoot) {
       // We're in the root timeline, render the canvas normally
@@ -63357,28 +63369,44 @@ Wick.View.Project = class extends Wick.View {
 
       this._svgBackgroundLayer.addChild(stage);
     } else {
-      // We're inside a clip, don't render the canvas BG, instead render a crosshair at (0,0)
+      // We're inside a clip, don't render the canvas BG directly, instead render a crosshair at (0,0)
       var originCrosshair = this._generateSVGOriginCrosshair();
 
       this._svgBackgroundLayer.addChild(originCrosshair);
 
       if (this.model.toolSettings.getSetting('outsideClipStyle') !== 'none') {
-        var thisParentLayer = this.model.focus.parentLayer;
-        var thisParentTimeline = thisParentLayer.parentTimeline;
-        thisParentTimeline.view.render();
+        if (this.model.toolSettings.getSetting('outsideClipShowBorder')) {
+          this._svgOuterLayer.addChild(this._generateSVGCanvasStage());
+        }
+
+        var rootTimeline = this.model.root.timeline;
+        var objectsGroup = new paper.Group();
+
+        this._svgOuterLayer.addChild(objectsGroup);
+
+        rootTimeline.view.render();
         this.model.focus.view.group.remove();
-        thisParentTimeline.view.frameLayers.forEach(layer => {
-          this._svgOuterLayer.addChild(layer);
+        rootTimeline.view.frameLayers.forEach(layer => {
+          objectsGroup.addChild(layer);
+        }); // Apply visual effects
+
+        var transformations = [];
+        var clipIteration = this.model.focus;
+
+        while (!clipIteration.isRoot) {
+          transformations.push(clipIteration.transformation);
+          clipIteration = clipIteration.parentClip;
+        }
+
+        transformations.reverse();
+        transformations.forEach(transform => {
+          this._svgOuterLayer.translate(-transform.x, -transform.y);
+
+          this._svgOuterLayer.rotate(-transform.rotation, new paper.Point());
+
+          this._svgOuterLayer.scale(1 / transform.scaleX, 1 / transform.scaleY, new paper.Point());
         });
-        var thisClipTransformation = this.model.focus.transformation;
-
-        this._svgOuterLayer.translate(-thisClipTransformation.x, -thisClipTransformation.y);
-
-        this._svgOuterLayer.rotate(-thisClipTransformation.rotation, new paper.Point());
-
-        this._svgOuterLayer.scale(1 / thisClipTransformation.scaleX, 1 / thisClipTransformation.scaleY, new paper.Point());
-
-        this._svgOuterLayer.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
+        objectsGroup.opacity = this.model.toolSettings.getSetting('outsideClipStandardOpacity');
       }
     } // Generate frame layers
 

--- a/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/EditorSettings.jsx
@@ -46,25 +46,36 @@ class EditorSettings extends Component {
       case 'standard':
         const inputRestrictions = this.props.getToolSettingRestrictions('outsideClipStandardOpacity');
         outsideClipStyleContent = (
-          <div className="editor-settings-row">
-            Object Opacity:
-            <div className="editor-settings-slider-row">
-              <WickInput
-                className="editor-settings-slider-row-slider"
-                type="slider"
-                id="editor-settings-outside-clip-opacity-slider"
-                value={this.props.getToolSetting('outsideClipStandardOpacity')}
-                onChange={(val) => {this.props.setToolSetting('outsideClipStandardOpacity', val)}}
-                {...inputRestrictions} />
-              <WickInput
-                className="editor-settings-slider-row-number"
-                type="numeric"
-                id="editor-settings-outside-clip-opacity-number"
-                value={this.props.getToolSetting('outsideClipStandardOpacity')}
-                onChange={(val) => {this.props.setToolSetting('outsideClipStandardOpacity', val)}}
-                {...inputRestrictions} />
+          <>
+            <div className="editor-settings-row">
+              Object Opacity:
+              <div className="editor-settings-slider-row">
+                <WickInput
+                  className="editor-settings-slider-row-slider"
+                  type="slider"
+                  id="editor-settings-outside-clip-opacity-slider"
+                  value={this.props.getToolSetting('outsideClipStandardOpacity')}
+                  onChange={(val) => {this.props.setToolSetting('outsideClipStandardOpacity', val)}}
+                  {...inputRestrictions} />
+                <WickInput
+                  className="editor-settings-slider-row-number"
+                  type="numeric"
+                  id="editor-settings-outside-clip-opacity-number"
+                  value={this.props.getToolSetting('outsideClipStandardOpacity')}
+                  onChange={(val) => {this.props.setToolSetting('outsideClipStandardOpacity', val)}}
+                  {...inputRestrictions} />
+              </div>
             </div>
-          </div>
+            <div className="editor-settings-row">
+              <WickInput
+                className="editor-settings-checkbox"
+                type="checkbox"
+                id="editor-settings-outside-clip-border-checkbox"
+                label="Show Main Borders"
+                checked={this.props.getToolSetting('outsideClipShowBorder')}
+                onChange={(val) => {this.props.setToolSetting('outsideClipShowBorder', !this.props.getToolSetting('outsideClipShowBorder'))}} />
+            </div>
+          </>
         );
         break;
       case 'none':

--- a/src/Editor/Modals/SettingsModal/EditorSettings/_editorsettings.scss
+++ b/src/Editor/Modals/SettingsModal/EditorSettings/_editorsettings.scss
@@ -99,3 +99,8 @@
 .editor-settings-slider-row-number {
   flex: 0 1 40px;
 }
+
+.editor-settings-checkbox {
+  min-width: 20px;
+  min-height: 20px;
+}


### PR DESCRIPTION
Might not be using "recursive" exactly right here, but this modifies the outside-clip view to show all outside layers up to the root, and it also adds an option to view the canvas in the root. Doesn't seem broken to me.